### PR TITLE
Add file size, MIME type to returned properties (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,11 @@ RNCOpenDoc.pick(null, (error, files) => {
     }
 });
 ```
-  
+ 
+`files` is an array of objects with the following properties:
+
+- `fileName` (string) e.g. "foo.html"
+- `fileSize` (number) (iOS only) File size in bytes
+- `mimeType` (string) (iOS only) e.g. "text/html"
+- `uri` (string) Example (iOS): "file:///private/var/mobile/Containers/Data/Application/.../foo.html"
+


### PR DESCRIPTION
Hey @blankg, this PR adds `fileSize` and `mimeType` to the returned properties in iOS. Let me know what you think. Cheers!