### PR TITLE
Fix Podspec

### DIFF
--- a/ios/RNCOpenDoc.podspec
+++ b/ios/RNCOpenDoc.podspec
@@ -6,13 +6,13 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNCOpenDoc
                    DESC
-  s.homepage     = ""
+  s.homepage     = "n/a"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "guy.blank@capriza.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/capriza/react-native-open-doc.git", :tag => "master" }
-  s.source_files  = "RNCOpenDoc/**/*.{h,m}"
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
 


### PR DESCRIPTION
This PR fixes two things in the Podspec:

1. I've put some placeholder value in the `homepage` property as this one is required by CocoaPods, i.e. it should be defined and must not be empty.
By defining an empty `homepage`, I got the following error using CocoaPods 1.9.1:
![Capture](https://user-images.githubusercontent.com/16084193/85755379-2cf68500-b70e-11ea-89ce-5c587b03017f.PNG)
This change fixes the issue

2. I corrected the `source_files` property by looking for source files in the correct folder. As `RNCOpenDoc.podspec` is in the same folder as the source files, CocoaPods was wrongly looking in `ios/RNCOpenDoc/**/*.{h,m}` instead of `ios/*.{h,m}`. This caused RNCOpenDoc not being linked correctly for me (no dynamic framework has been generated).

I want to mention that I am using React Native 0.61.4 with auto linking and `use_frameworks!`, so I did not use the `react-native link` command.